### PR TITLE
Changes to nationalism

### DIFF
--- a/CWE/poptypes/aristocrats.txt
+++ b/CWE/poptypes/aristocrats.txt
@@ -271,7 +271,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
@@ -295,14 +296,15 @@ modifier = { factor = 1.1 country = { has_country_flag = resolution_vetoed_unsc 
 
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no is_accepted_culture = no } country = { NOT = { minorities_reform = minorities_oppression } } NOT = { government = nationalist_dictatorship } }
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/artisans.txt
+++ b/CWE/poptypes/artisans.txt
@@ -357,7 +357,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
@@ -377,14 +378,15 @@ modifier = { factor = 1.1 country = { has_country_flag = resolution_vetoed_unsc 
 
 
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/bureaucrats.txt
+++ b/CWE/poptypes/bureaucrats.txt
@@ -366,7 +366,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
@@ -386,14 +387,15 @@ modifier = { factor = 1.1 country = { has_country_flag = anti_war_strike } }
 
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no is_accepted_culture = no } country = { NOT = { minorities_reform = minorities_oppression } } NOT = { government = nationalist_dictatorship } }
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/capitalists.txt
+++ b/CWE/poptypes/capitalists.txt
@@ -272,7 +272,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
@@ -294,14 +295,15 @@ modifier = { factor = 1.1 country = { has_country_flag = anti_war_strike } }
 
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no is_accepted_culture = no } country = { NOT = { minorities_reform = minorities_oppression } } NOT = { government = nationalist_dictatorship } }
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/clergymen.txt
+++ b/CWE/poptypes/clergymen.txt
@@ -773,7 +773,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } } 
 
 
 
@@ -793,14 +794,15 @@ modifier = { factor = 1.1 country = { has_country_flag = resolution_vetoed_unsc 
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no is_accepted_culture = no } country = { NOT = { minorities_reform = minorities_oppression } } NOT = { government = nationalist_dictatorship } }
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/clerks.txt
+++ b/CWE/poptypes/clerks.txt
@@ -500,7 +500,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } } 
 
 
 # Dynamic Decisions
@@ -521,14 +522,15 @@ modifier = { factor = 1.1 country = { has_country_flag = oil_cartel } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no is_accepted_culture = no } country = { NOT = { minorities_reform = minorities_oppression } } NOT = { government = nationalist_dictatorship } }
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/craftsmen.txt
+++ b/CWE/poptypes/craftsmen.txt
@@ -358,7 +358,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
@@ -381,14 +382,15 @@ modifier = { factor = 1.1 country = { has_country_flag = resolution_vetoed_unsc 
 
 
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/farmers.txt
+++ b/CWE/poptypes/farmers.txt
@@ -736,7 +736,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 
@@ -765,14 +766,15 @@ modifier = { factor = 1.1 country = { has_country_flag = resolution_vetoed_unsc 
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no is_accepted_culture = no } country = { NOT = { minorities_reform = minorities_oppression } } NOT = { government = nationalist_dictatorship } }
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/labourers.txt
+++ b/CWE/poptypes/labourers.txt
@@ -738,7 +738,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 
@@ -763,14 +764,15 @@ modifier = { factor = 1.1 country = { has_country_flag = resolution_vetoed_unsc 
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no is_accepted_culture = no } country = { NOT = { minorities_reform = minorities_oppression } } NOT = { government = nationalist_dictatorship } }
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/officers.txt
+++ b/CWE/poptypes/officers.txt
@@ -344,7 +344,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 4.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no } 
 		# geography
 		modifier = { factor = 4.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression NOT = { government = nationalist_dictatorship } }
 		modifier = { factor = 4.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } NOT = { government = nationalist_dictatorship } }
@@ -366,14 +367,15 @@ modifier = { factor = 1.1 country = { has_country_flag = anti_war_strike } }
 
 
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }

--- a/CWE/poptypes/soldiers.txt
+++ b/CWE/poptypes/soldiers.txt
@@ -357,7 +357,8 @@ ideologies = {
 		# type
 		# government and ruling_party_ideology
 		modifier = { factor = 10.0 is_primary_culture = yes government = nationalist_dictatorship } 
-		modifier = { factor = 0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } }
+		modifier = { factor = -2.0 location = { is_primary_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no }
+		modifier = { factor = -2.0 location = { is_accepted_culture = yes } NOT = { government = nationalist_dictatorship } is_vassal = no } 
 		# geography
 		modifier = { factor = 10.0 location = { is_overseas = no is_primary_culture = no is_accepted_culture = no } minorities_reform = minorities_oppression }
 		modifier = { factor = 10.0 location = { OR = { is_colonial = yes is_overseas = yes } is_primary_culture = no } country = { minorities_reform = minorities_oppression } }
@@ -382,14 +383,15 @@ modifier = { factor = 1.1 country = { has_country_flag = resolution_vetoed_unsc 
 
 
 		# ideology special
-		modifier = { factor = 1.2 militancy = 1 }
-		modifier = { factor = 1.2 militancy = 2 }
-		modifier = { factor = 1.2 militancy = 3 }
-		modifier = { factor = 1.2 militancy = 4 }
-		modifier = { factor = 1.2 militancy = 6 }
-		modifier = { factor = 1.2 militancy = 7 }
-		modifier = { factor = 1.2 militancy = 8 }
-		modifier = { factor = 1.2 militancy = 9 }
+		modifier = { factor = 1.2 AND = { militancy = 1  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 2  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 3  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 4  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 5  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 6  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 7  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 8  NOT = { ruling_party_ideology = nationalist } } }
+		modifier = { factor = 1.2 AND = { militancy = 9  NOT = { ruling_party_ideology = nationalist } } }
 		modifier = { factor = 1.2 consciousness = 1 }
 		modifier = { factor = 1.2 consciousness = 2 }
 		modifier = { factor = 1.2 consciousness = 3 }


### PR DESCRIPTION
Some changes to nationalists for post-colonial states.

1. Primary and accepted cultures now have -300% nationalist attraction if the government is not a sectarian regime. It doesn't really make sense for accepted cultures to be nationalistic if they're integrated into the national consciousness, so passing the "Nation of Equals" acts will now make your country noticeably stronger. 

2. Nationalists no longer gain support for having high militancy if they are in power. High militancy means people are angry at the government, this should not help nationalists if they are in power. 

What these changes do is they make it so that postcolonial nations that make an effort to incorporate all of their minorities will have a much easier time than those who reject their minorities (as makes sense.) For the first few years after independence there is high nationalism (simulating people's pride in their country after independence,) but after that honeymoon period nationalism stops being relev